### PR TITLE
Update the kernel config to be approprate for our kernel source

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -50,7 +50,7 @@ BOARD_KERNEL_PAGESIZE := 2048
 BOARD_KERNEL_SEPARATED_DT := true
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset 0x02000000 --tags_offset 0x01e00000
 TARGET_KERNEL_ARCH := arm
-TARGET_KERNEL_CONFIG := bacon_defconfig
+TARGET_KERNEL_CONFIG := cyanogenmod_bacon_defconfig
 TARGET_KERNEL_SOURCE := kernel/oneplus/msm8974
 
 # Enable DIAG on debug builds


### PR DESCRIPTION
[Our kernel source](https://github.com/ubports/android_kernel_oneplus_msm8974/tree/ubp-5.1) has a `cyanogenmod_bacon_defconfig` file, not `bacon_defconfig`