### PR TITLE
change ownership of gesture enabling files in /proc/touchpanel to android_input.

### DIFF
--- a/rootdir/root/init.qcom-common.rc
+++ b/rootdir/root/init.qcom-common.rc
@@ -248,19 +248,19 @@ on post-fs-data
     mkdir /data/audio/ 0770 media audio
 
     # Touchscreen
-    chown system radio /proc/touchpanel/double_tap_enable
+    chown system android_input /proc/touchpanel/double_tap_enable
     chmod 0660 /proc/touchpanel/double_tap_enable
 
-    chown root system /proc/touchpanel/camera_enable
+    chown root android_input /proc/touchpanel/camera_enable
     chmod 0660 /proc/touchpanel/camera_enable
 
-    chown root system /proc/touchpanel/music_enable
+    chown root android_input /proc/touchpanel/music_enable
     chmod 0660 /proc/touchpanel/music_enable
 
-    chown root system /proc/touchpanel/flashlight_enable
+    chown root android_input /proc/touchpanel/flashlight_enable
     chmod 0660 /proc/touchpanel/flashlight_enable
 
-    chown root system /proc/touchpanel/keypad_enable
+    chown root android_input /proc/touchpanel/keypad_enable
     chmod 0660 /proc/touchpanel/keypad_enable
 
     chown system system /sys/devices/virtual/graphics/fb0/cabc


### PR DESCRIPTION


Any member of android_input should be able to enable/disable gestures from the touch panel.

Change-Id: Id54c98b4eb310b23bc6cc0e2c7d1d9bb6cc385ef