### PR TITLE
fix changing ownership of files in /proc/touchpanel.

### DIFF
--- a/rootdir/root/init.bacon.rc
+++ b/rootdir/root/init.bacon.rc
@@ -49,6 +49,14 @@ on post-fs-data
     chmod 0660 /sys/class/leds/torch-light/brightness
     chmod 0660 /sys/class/leds/led\:flash_torch/brightness
 
+    # gestures. gid 1004 is android_input
+    chown system 1004 /proc/touchpanel/double_tap_enable
+    chown system 1004 /proc/touchpanel/camera_enable
+    chown system 1004 /proc/touchpanel/music_enable
+    chown system 1004 /proc/touchpanel/flashlight_enable
+    chown system 1004 /proc/touchpanel/keypad_enable
+
+
 
 # virtual sdcard daemon running as media_rw (1023)
 #service sdcard /system/bin/sdcard -u 1023 -g 1023 -l /data/media /mnt/shell/emulated

--- a/rootdir/root/init.qcom-common.rc
+++ b/rootdir/root/init.qcom-common.rc
@@ -248,19 +248,19 @@ on post-fs-data
     mkdir /data/audio/ 0770 media audio
 
     # Touchscreen
-    chown system android_input /proc/touchpanel/double_tap_enable
+    chown system radio /proc/touchpanel/double_tap_enable
     chmod 0660 /proc/touchpanel/double_tap_enable
 
-    chown root android_input /proc/touchpanel/camera_enable
+    chown root system /proc/touchpanel/camera_enable
     chmod 0660 /proc/touchpanel/camera_enable
 
-    chown root android_input /proc/touchpanel/music_enable
+    chown root system /proc/touchpanel/music_enable
     chmod 0660 /proc/touchpanel/music_enable
 
-    chown root android_input /proc/touchpanel/flashlight_enable
+    chown root system /proc/touchpanel/flashlight_enable
     chmod 0660 /proc/touchpanel/flashlight_enable
 
-    chown root android_input /proc/touchpanel/keypad_enable
+    chown root system /proc/touchpanel/keypad_enable
     chmod 0660 /proc/touchpanel/keypad_enable
 
     chown system system /sys/devices/virtual/graphics/fb0/cabc


### PR DESCRIPTION
Sorry. The previous PR did not fix it. This one does.
```
phablet@ubuntu-phablet:~$ ls -l /proc/touchpanel/
total 0
-rw-rw---- 1 root   android_input 0 Dec 28 17:24 camera_enable
-rw-rw---- 1 system android_input 0 Dec 28 17:24 double_tap_enable
-rw-rw---- 1 root   android_input 0 Dec 28 17:24 flashlight_enable
-rw-rw---- 1 root   android_input 0 Dec 28 17:24 keypad_enable
-rw-rw---- 1 root   android_input 0 Dec 28 17:24 music_enable
```

Although I don't understand why double_tap_enable becomes owned by system and the rest remains owned by root.

Change-Id: Ifda439af04078ddeefb11de653c86b289e664d12