### PR TITLE
fix bluetooth address

### DIFF
--- a/rootdir/root/init_wlan_bt.sh
+++ b/rootdir/root/init_wlan_bt.sh
@@ -7,8 +7,6 @@
 rm /data/misc/wifi/WCNSS_qcom_cfg.ini
 rm /data/misc/wifi/WCNSS_qcom_wlan_nv.bin
 
-logwrapper /system/bin/conn_init
-
 echo 1 > /dev/wcnss_wlan
 
 enable_bt () {
@@ -18,10 +16,10 @@ enable_bt () {
         fi
 
         #initialize bt device
-        /system/bin/hci_qcomm_init -e
-        sleep 1 
+        echo 0 > /sys/module/hci_smd/parameters/hcismd_set
+        /system/bin/logwrapper -k /system/bin/hci_qcomm_init -vvv -e
+        sleep 1
         echo 1 > /sys/module/hci_smd/parameters/hcismd_set
-
 
 }
 


### PR DESCRIPTION
With these changes I get:

phablet@ubuntu-phablet:~$ hciconfig
hci0:   Type: Primary  Bus: SPI
        BD Address: C0:EE:FB:28:A9:A6  ACL MTU: 1024:6  SCO MTU: 50:8
        DOWN
        RX bytes:0 acl:0 sco:0 events:31 errors:0
        TX bytes:0 acl:0 sco:0 commands:0 errors:0