### PR TITLE
treewide: Fix installer support

### DIFF
--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Apply device-specific patches
+
+OLD_WD=$(pwd)
+DEVICE_PATH=device/oneplus/bacon/patches
+
+for patch in `find $DEVICE_PATH -name *.patch | sort | awk -F $DEVICE_PATH '{print $2}'`; do
+    cd $OLD_WD/./$(dirname $patch)
+    if patch -p1 -N --dry-run --silent < $OLD_WD/$DEVICE_PATH/$patch 2>/dev/null; then
+        patch -p1 < $OLD_WD/$DEVICE_PATH/$patch
+    fi
+done

--- a/patches/bootable/recovery/0001-system-image-upgrader-Patch-up-script-for-data-insta.patch
+++ b/patches/bootable/recovery/0001-system-image-upgrader-Patch-up-script-for-data-insta.patch
@@ -1,0 +1,76 @@
+From 95f6713eea39d31db207ceccd77f9cad6a0377a2 Mon Sep 17 00:00:00 2001
+From: Muhammad <muhammad23012009@hotmail.com>
+Date: Sat, 1 Apr 2023 20:26:53 +0500
+Subject: [PATCH] system-image-upgrader: Patch up script for /data installation
+
+Change-Id: Ie25b5a1ee37d4bf7a32145829b9aa188e0a7175b
+Signed-off-by: Muhammad <muhammad23012009@hotmail.com>
+---
+ system-image-upgrader | 23 +++++++----------------
+ 1 file changed, 7 insertions(+), 16 deletions(-)
+
+diff --git a/system-image-upgrader b/system-image-upgrader
+index 2c5e1d2..be0a423 100755
+--- a/system-image-upgrader
++++ b/system-image-upgrader
+@@ -262,17 +262,8 @@ if [ -e /etc/system-image/archive-master.tar.xz ]; then
+     install_keyring /etc/system-image/archive-master.tar.xz /etc/system-image/archive-master.tar.xz.asc
+ fi
+ 
+-# Check the kernel command line to see whether Ubuntu should be installed to a partition
+-# or in a file that is loop mounted.
+-#if grep -q systempart= /proc/cmdline; then
+-#    USE_SYSTEM_PARTITION=1
+-#else
+-#    USE_SYSTEM_PARTITION=0
+-#fi
+-
+-# Force usage of system partition for now, the existance of Android 9.0 devices
+-# with a too small system partition is questionable at this point.
+-USE_SYSTEM_PARTITION=1
++# We have to force using data partition instead of system for this
++USE_SYSTEM_PARTITION=0
+ 
+ # However, do not use the block device name in the kernel command line, as that is not consistently
+ # named in booting normal and recovery modes. Expect fstab to have a system mountpoint or use a fallback.
+@@ -308,8 +299,8 @@ do
+                         mkfs.ext4 $SYSTEM_PARTITION
+                     else
+                         # We need to use legacy image name here, halium-boot needs this to decide file layout
+-                        dd if=/dev/zero of=/data/ubuntu.img seek=500K bs=4096 count=0
+-                        mkfs.ext2 -F /data/ubuntu.img
++                        dd if=/dev/zero of=/data/ubuntu.img seek=1000K bs=4096 count=0
++                        mkfs.ext4 -F /data/ubuntu.img
+                     fi
+                 ;;
+ 
+@@ -317,7 +308,7 @@ do
+                     mount /data || true
+                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
+                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ]; then
+-                            if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) || ( "$entry" == "/data/android-rootfs.img" ) ]]; then
++                            if [ "$entry" == "/data/ubuntu.img" ] || [ "$entry" == "/data/rootfs.img" ] || [ "$entry" == "/data/system.img" ] || [ "$entry" == "/data/android-rootfs.img" ]; then
+                                     continue
+                             fi
+                         fi
+@@ -345,7 +336,7 @@ do
+                     # mtp is always enabled by default
+                     usb_enable mtp
+                     DATA_FORMAT=1
+-                    umount /data
++                    umount /data || true
+                 ;;
+ 
+                 *)
+@@ -574,7 +565,7 @@ echo "Done upgrading..."
+ # else filling $HOME can make the system unusable since writable
+ # files and dirs share the space with $HOME and android does not
+ # reserve root space in /data
+-mount /data
++mount /data || true
+ tune2fs -m 5 $(grep "/data " /proc/mounts| sed -e 's/ .*$//')
+ umount /data
+ 
+-- 
+2.39.2
+

--- a/rootdir/etc/fstab.recovery
+++ b/rootdir/etc/fstab.recovery
@@ -3,7 +3,7 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/platform/msm_sdcc.1/by-name/system       /system         ext4    ro,barrier=1                                                    wait
+/dev/block/platform/msm_sdcc.1/by-name/system       /system_root         ext4    ro,barrier=1                                                    wait
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic,journal_async_commit wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/reserve4
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           f2fs    noatime,nosuid,nodev,rw,inline_xattr                            wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/reserve4
 /dev/block/platform/msm_sdcc.1/by-name/cache        /cache          ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic,journal_async_commit wait,check,formattable

--- a/ubuntu/recovery/ubports-mounter.sh
+++ b/ubuntu/recovery/ubports-mounter.sh
@@ -2,19 +2,28 @@
 
 DATA_MOUNT_CODE=1
 
+RETRY_COUNTER=0
 while [ "$DATA_MOUNT_CODE" != "0" ]; do
-    mount -t ext4 /dev/block/by-name/userdata /data > /dev/kmsg
+    if [ "$RETRY_COUNTER" -gt "3" ]; then
+        echo "setup_fake_cache.sh - reached maximum number of retries" > /dev/kmsg
+
+        setprop halium.datamount.done 1
+        exit 1
+    fi
+    RETRY_COUNTER=$((RETRY_COUNTER+1))
+
+    mount /dev/block/by-name/userdata /data > /dev/kmsg
     DATA_MOUNT_CODE=$?
-    sleep 1
 done
 
-mkdir /cache > /dev/kmsg
-mkdir /data/android-data > /dev/kmsg
-mkdir /data/android-data/cache > /dev/kmsg
-mkdir /data/android-data/cache/recovery > /dev/kmsg
-mount -o bind /data/android-data/cache /cache > /dev/kmsgs
+mkdir /data/cache/ > /dev/kmsg
+mkdir /data/cache/recovery/ > /dev/kmsg
+
+while [ "$DATA_MOUNT_CODE" == "0" ]; do
+    if [ ! -d /cache/recovery ]; then
+        mount --bind /data/cache /cache > /dev/kmsg
+    fi
+done
 
 setprop halium.datamount.done 1
-
 exit 0
-

--- a/ubuntu/recovery/ubports-mounter.sh
+++ b/ubuntu/recovery/ubports-mounter.sh
@@ -19,11 +19,10 @@ done
 mkdir /data/cache/ > /dev/kmsg
 mkdir /data/cache/recovery/ > /dev/kmsg
 
-while [ "$DATA_MOUNT_CODE" == "0" ]; do
-    if [ ! -d /cache/recovery ]; then
-        mount --bind /data/cache /cache > /dev/kmsg
-    fi
-done
+if [ "$DATA_MOUNT_CODE" == "0" ]; then
+    mkdir /data/cache > /dev/kmsg
+    mount -o bind /data/cache /cache > /dev/kmsg
+fi
 
 setprop halium.datamount.done 1
 exit 0

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,0 +1,1 @@
+sh device/oneplus/bacon/patches/apply.sh;


### PR DESCRIPTION
* Rename /system mount to /system_root (needed for some odd reason)
* Add patch for bootable/recovery to work with data partition install
* Add fake cache service