### PR TITLE
fstab: remove /cache mounts

### DIFF
--- a/rootdir/etc/fstab.bacon
+++ b/rootdir/etc/fstab.bacon
@@ -5,8 +5,6 @@
 
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic,journal_async_commit wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/reserve4
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           f2fs    noatime,nosuid,nodev,rw,inline_xattr                            wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/reserve4
-/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic,journal_async_commit wait,check,formattable
-/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          f2fs    noatime,nosuid,nodev,rw,inline_xattr                            wait,check,formattable
 /dev/block/platform/msm_sdcc.1/by-name/persist      /persist        ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,check,notrim
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot           emmc    defaults                                                        defaults
 /dev/block/platform/msm_sdcc.1/by-name/recovery     /recovery       emmc    defaults                                                        defaults


### PR DESCRIPTION
* this breaks our bind-mount when `mount -a` is ran in recovery (which installer runs). remove this to fix all issues